### PR TITLE
Adding in an image for the queue runner

### DIFF
--- a/deploy/queue.docker
+++ b/deploy/queue.docker
@@ -1,0 +1,7 @@
+FROM php:7
+
+RUN apt-get update && apt-get install -y libmcrypt-dev mysql-client \
+    && docker-php-ext-install mcrypt pdo_mysql
+
+WORKDIR /var/www
+CMD ["/bin/sh", "./docker/queue.sh"]

--- a/deploy/queue.sh
+++ b/deploy/queue.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+while true;
+do
+    php artisan queue:work --daemon
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,14 @@ services:
         image: redis:3.0
         ports:
             - "63791:6379"
+    queue:
+        build:
+            context: ./
+            dockerfile: deploy/queue.docker
+        volumes:
+            - ./:/var/www
+        links:
+            - database
+        environment:
+            - "DB_PORT=3306"
+            - "DB_HOST=database"


### PR DESCRIPTION
The image won't shut down if you do a `php artisan queue:restart`, instead
it will restart the queue runner so you can update anything you want
